### PR TITLE
TCC install: use --disable-static instead of sed//-fPIC/ (creds. F. Monjalet)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get -qq update && \
 RUN cd /opt && \
     git clone http://repo.or.cz/tinycc.git tinycc && \
     cd tinycc && \
-    sed --in-place "s/CFLAGS+=-fno-strict-aliasing/CFLAGS+=-fno-strict-aliasing -fPIC/g" Makefile && \
-    ./configure && \
+    ./configure --disable-static && \
     make && \
     make install && \
     make clean


### PR DESCRIPTION
Take in account https://github.com/cea-sec/miasm/issues/36.

Basically, use the `--disable-static` option of `configure` instead of hacking `Makefile` through `sed`.